### PR TITLE
adding support for receiving a beats input

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/centos-7.2"
   config.vm.network "forwarded_port", guest: 80, host: 8000
   config.vm.network "forwarded_port", guest: 9200, host: 9200
+  config.vm.network "forwarded_port", guest: 5044, host: 5044
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "9216"
   end

--- a/cookbooks/PetELK/recipes/default.rb
+++ b/cookbooks/PetELK/recipes/default.rb
@@ -326,6 +326,10 @@ template '/etc/logstash/conf.d/files.conf' do
   source 'files.conf.erb'
 end
 
+template '/etc/logstash/conf.d/beats.conf' do
+  source 'beats.conf.erb'
+end 
+
 service 'logstash' do
   action [ :enable, :start ]
 end

--- a/cookbooks/PetELK/templates/default/beats.conf.erb
+++ b/cookbooks/PetELK/templates/default/beats.conf.erb
@@ -1,0 +1,20 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+  json {
+    source => "message"
+  }
+}
+
+output {
+  #stdout { codec => rubydebug }
+  elasticsearch {
+    hosts => ["127.0.0.1:9200"]
+    user => "elastic"
+    password => "changeme"
+  }
+}


### PR DESCRIPTION
This is great, but recently I found it helpful to be able to simply forward events from beats on the host machine while I worked. 

Logstash's beats.con is essentially a clone to the existing file.conf for the output section, simply added the beats standard port on the input plugin and the json filter on the message field (keeping in line with the existing principle of giving PetELK json to consume). 